### PR TITLE
fix: add Write tool to all reviewer agents

### DIFF
--- a/agents/assumption-hunter.md
+++ b/agents/assumption-hunter.md
@@ -22,7 +22,7 @@ description: |
   </example>
 model: sonnet
 color: yellow
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Assumption Hunter — an adversarial design reviewer who finds what the designer took for granted.

--- a/agents/constraint-finder.md
+++ b/agents/constraint-finder.md
@@ -13,7 +13,7 @@ description: |
   </example>
 model: sonnet
 color: red
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Constraint Finder — a requirements reviewer who identifies limits and feasibility concerns.

--- a/agents/edge-case-prober.md
+++ b/agents/edge-case-prober.md
@@ -22,7 +22,7 @@ description: |
   </example>
 model: sonnet
 color: red
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Edge Case Prober — an adversarial design reviewer who finds what breaks when things go wrong or weird.

--- a/agents/feasibility-skeptic.md
+++ b/agents/feasibility-skeptic.md
@@ -22,7 +22,7 @@ description: |
   </example>
 model: sonnet
 color: magenta
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Feasibility Skeptic — an adversarial design reviewer who probes whether the design is actually buildable and whether it's the simplest viable approach.

--- a/agents/first-principles.md
+++ b/agents/first-principles.md
@@ -22,7 +22,7 @@ description: |
   </example>
 model: sonnet
 color: green
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the First Principles Challenger — an adversarial design reviewer who strips away inherited assumptions and asks whether the problem framing itself is right.

--- a/agents/prior-art-scout.md
+++ b/agents/prior-art-scout.md
@@ -22,7 +22,7 @@ description: |
   </example>
 model: sonnet
 color: blue
-tools: ["Read", "Grep", "Glob", "WebSearch"]
+tools: ["Read", "Grep", "Glob", "WebSearch", "Write"]
 ---
 
 You are the Prior Art Scout — an adversarial design reviewer who checks whether the design reinvents existing solutions, ignores industry standards, or builds what it should buy.

--- a/agents/problem-framer.md
+++ b/agents/problem-framer.md
@@ -13,7 +13,7 @@ description: |
   </example>
 model: sonnet
 color: blue
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Problem Framer — a requirements reviewer who validates whether the team is solving the right problem.

--- a/agents/requirement-auditor.md
+++ b/agents/requirement-auditor.md
@@ -22,7 +22,7 @@ description: |
   </example>
 model: sonnet
 color: cyan
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Requirement Auditor — an adversarial design reviewer who checks whether the design actually delivers what was required, nothing more, nothing less.

--- a/agents/scope-guardian.md
+++ b/agents/scope-guardian.md
@@ -13,7 +13,7 @@ description: |
   </example>
 model: sonnet
 color: purple
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Scope Guardian — a requirements reviewer who validates scope boundaries and MVP definition.

--- a/agents/success-validator.md
+++ b/agents/success-validator.md
@@ -13,7 +13,7 @@ description: |
   </example>
 model: sonnet
 color: green
-tools: ["Read", "Grep", "Glob"]
+tools: ["Read", "Grep", "Glob", "Write"]
 ---
 
 You are the Success Validator — a requirements reviewer who validates measurable success criteria.


### PR DESCRIPTION
## Problem

Reviewer agents were missing the `Write` tool in their YAML frontmatter, preventing them from writing JSONL output files directly.

During manual testing of `parallax:requirements --light`, agents output JSONL content in their responses instead of writing files, requiring manual file creation by the orchestrator.

## Solution

Added `"Write"` to the `tools` array for all 10 affected reviewer agents:

**Requirements review (4):**
- problem-framer
- scope-guardian  
- constraint-finder
- success-validator

**Design review (6):**
- assumption-hunter
- edge-case-prober
- requirement-auditor
- feasibility-skeptic
- first-principles
- prior-art-scout

**Note:** `review-synthesizer` already had Write tool.

## Changes

```yaml
# Before
tools: ["Read", "Grep", "Glob"]

# After  
tools: ["Read", "Grep", "Glob", "Write"]
```

Special case for `prior-art-scout`:
```yaml
# Before
tools: ["Read", "Grep", "Glob", "WebSearch"]

# After
tools: ["Read", "Grep", "Glob", "WebSearch", "Write"]
```

## Testing

After merge, re-run `parallax:requirements --light` and verify:
- Agents write JSONL files directly to `docs/reviews/<topic>/findings-v1-<persona>.jsonl`
- No manual file writing required
- Synthesis proceeds immediately after agent completion

## Related

- Issue #35 (this fix)
- PR #32 (requirements light implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)