### PR TITLE
docs: promote worktree workflow rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ The name comes from parallax — the apparent shift in an object's position when
 - A pre-commit hook enforces this (see `hooks/pre-commit`)
 - New clones: Run `git config core.hooksPath hooks` to enable the hook
 
+## Worktree Workflow
+
+Always `cd` to the worktree first via a full absolute path (`cd /full/path && ...`) so all subsequent commands run in the correct context. Never use `make -C` or relative paths like `.worktrees/...` — they fail when shell CWD doesn't match.
+
 ## Subagent Tool Discipline
 
 Subagents inherit these rules. **Use dedicated tools, not bash equivalents:**


### PR DESCRIPTION
## Summary
- Promotes the worktree workflow rule from machine-local MEMORY.md to git-tracked CLAUDE.md so it travels across machines and clones
- Rule: always `cd` to worktree via full absolute path; never `make -C` or relative `.worktrees/...` paths

## Test plan
- [ ] Verify CLAUDE.md loads correctly in a fresh Claude Code session in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)