### PR TITLE
feat: reviewer confidence self-scoring + synthesizer filter (#72)

### DIFF
--- a/agents/assumption-hunter.md
+++ b/agents/assumption-hunter.md
@@ -63,6 +63,7 @@ Produce JSONL findings using this structure (one JSON object per line):
   "id": "assumption-hunter-NNN",
   "title": "Brief finding title",
   "severity": "Critical|Important|Minor",
+  "confidence": 85,
   "phase": {
     "primary": "survey|calibrate|design|plan",
     "contributing": null
@@ -82,6 +83,7 @@ After completing your review, add a blind spot check meta-finding:
   "id": "assumption-hunter-999",
   "title": "Blind spot check: Assumption Hunter perspective",
   "severity": "Minor",
+  "confidence": 50,
   "phase": {
     "primary": "design",
     "contributing": null
@@ -97,6 +99,21 @@ After completing your review, add a blind spot check meta-finding:
 - **Critical:** The design cannot work if this assumption is wrong. Blocks progress.
 - **Important:** The design degrades significantly if this assumption is wrong. Should address before building.
 - **Minor:** The assumption is probably safe but worth stating explicitly.
+
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
 
 **Phase classification (assign primary, optionally note contributing):**
 - **survey:** The assumption reflects missing research ("assumes X exists" but no one checked)

--- a/agents/constraint-finder.md
+++ b/agents/constraint-finder.md
@@ -52,6 +52,7 @@ Produce JSONL findings using this structure:
   "id": "constraint-finder-NNN",
   "title": "Brief finding title",
   "severity": "Critical|Important|Minor",
+  "confidence": 85,
   "phase": {
     "primary": "calibrate",
     "contributing": null
@@ -68,6 +69,21 @@ Produce JSONL findings using this structure:
 - **Important:** Key constraints unstated, feasibility unclear (causes rework)
 - **Minor:** Clarity improvements, documentation gaps
 
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
+
 **Blind spot check:**
 
 After completing your review, add a meta-finding:
@@ -78,6 +94,7 @@ After completing your review, add a meta-finding:
   "id": "constraint-finder-999",
   "title": "Blind spot check: Constraint Finder perspective",
   "severity": "Minor",
+  "confidence": 50,
   "phase": {
     "primary": "calibrate",
     "contributing": null

--- a/agents/edge-case-prober.md
+++ b/agents/edge-case-prober.md
@@ -64,6 +64,7 @@ Write your findings as structured markdown:
 
 ### Finding N: [Title]
 - **Severity:** Critical | Important | Minor
+- **Confidence:** 85/100
 - **Phase:** [primary phase] (primary), [contributing phase] (contributing, if applicable)
 - **Section:** [which part of the design]
 - **Issue:** [what edge case or failure mode was found]
@@ -78,6 +79,21 @@ Write your findings as structured markdown:
 - **Critical:** Unhandled failure mode that causes data loss, corruption, or complete system failure.
 - **Important:** Edge case that degrades user experience significantly or causes silent errors.
 - **Minor:** Uncommon edge case worth documenting but unlikely to cause real harm.
+
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
 
 **Phase classification (assign primary, optionally note contributing):**
 - **survey:** Missing research about failure modes in similar systems

--- a/agents/feasibility-skeptic.md
+++ b/agents/feasibility-skeptic.md
@@ -69,6 +69,7 @@ Write your findings as structured markdown:
 
 ### Finding N: [Title]
 - **Severity:** Critical | Important | Minor
+- **Confidence:** 85/100
 - **Phase:** [primary phase] (primary), [contributing phase] (contributing, if applicable)
 - **Section:** [which part of the design]
 - **Issue:** [what feasibility concern was found]
@@ -83,6 +84,21 @@ Write your findings as structured markdown:
 - **Critical:** A core component is significantly harder than the design acknowledges, threatening the whole project.
 - **Important:** A component is more complex than it appears, likely causing delays or requiring design changes.
 - **Minor:** Something could be simpler but the current approach is workable.
+
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
 
 **Phase classification (assign primary, optionally note contributing):**
 - **survey:** Missing research about a technology's actual capabilities or limitations

--- a/agents/first-principles.md
+++ b/agents/first-principles.md
@@ -66,6 +66,7 @@ Write your findings as structured markdown:
 
 ### Finding N: [Title]
 - **Severity:** Critical | Important | Minor
+- **Confidence:** 85/100
 - **Phase:** [primary phase] (primary), [contributing phase] (contributing, if applicable)
 - **Section:** [which part of the design]
 - **Issue:** [what first-principles concern was found]
@@ -80,6 +81,21 @@ Write your findings as structured markdown:
 - **Critical:** The design is solving the wrong problem or a symptom instead of the root cause.
 - **Important:** A significant design choice is driven by precedent rather than necessity, and a better alternative exists.
 - **Minor:** An inherited assumption that's probably fine but worth questioning.
+
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
 
 **Phase classification (assign primary, optionally note contributing):**
 - **survey:** The problem itself needs more investigation

--- a/agents/prior-art-scout.md
+++ b/agents/prior-art-scout.md
@@ -66,6 +66,7 @@ Write your findings as structured markdown:
 
 ### Finding N: [Title]
 - **Severity:** Critical | Important | Minor
+- **Confidence:** 85/100
 - **Phase:** [primary phase] (primary), [contributing phase] (contributing, if applicable)
 - **Section:** [which part of the design]
 - **Issue:** [what prior art or standard was missed]
@@ -80,6 +81,21 @@ Write your findings as structured markdown:
 - **Critical:** The design builds a major component that a well-maintained existing solution handles well, wasting significant effort.
 - **Important:** The design ignores a relevant standard or pattern, creating integration friction or maintenance burden.
 - **Minor:** A minor component could use an existing library but the custom approach is acceptable.
+
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
 
 **Phase classification (assign primary, optionally note contributing):**
 - **survey:** Missing research about existing solutions in this space

--- a/agents/problem-framer.md
+++ b/agents/problem-framer.md
@@ -52,6 +52,7 @@ Produce JSONL findings using this structure:
   "id": "problem-framer-NNN",
   "title": "Brief finding title",
   "severity": "Critical|Important|Minor",
+  "confidence": 85,
   "phase": {
     "primary": "calibrate",
     "contributing": null
@@ -68,6 +69,21 @@ Produce JSONL findings using this structure:
 - **Important:** Root cause unclear, impact not stated, scope ambiguous (causes rework)
 - **Minor:** Clarity improvements, documentation gaps
 
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
+
 **Blind spot check:**
 
 After completing your review, add a meta-finding:
@@ -78,6 +94,7 @@ After completing your review, add a meta-finding:
   "id": "problem-framer-999",
   "title": "Blind spot check: Problem Framer perspective",
   "severity": "Minor",
+  "confidence": 50,
   "phase": {
     "primary": "calibrate",
     "contributing": null

--- a/agents/requirement-auditor.md
+++ b/agents/requirement-auditor.md
@@ -72,6 +72,7 @@ Write your findings as structured markdown:
 
 ### Finding N: [Title]
 - **Severity:** Critical | Important | Minor
+- **Confidence:** 85/100
 - **Phase:** [primary phase] (primary), [contributing phase] (contributing, if applicable)
 - **Section:** [which part of the design]
 - **Issue:** [what requirement problem was found]
@@ -86,6 +87,21 @@ Write your findings as structured markdown:
 - **Critical:** A must-have requirement is unaddressed or contradicted.
 - **Important:** A should-have requirement is partially addressed or a clear YAGNI violation adds significant complexity.
 - **Minor:** A nice-to-have is missing or a small gold-plating instance.
+
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
 
 **Phase classification (assign primary, optionally note contributing):**
 - **survey:** Requirement references something that wasn't researched

--- a/agents/review-synthesizer.md
+++ b/agents/review-synthesizer.md
@@ -30,6 +30,7 @@ You are the Review Synthesizer — an editorial agent that consolidates findings
 **Your role requires judgment.** Deduplication, phase classification, and contradiction surfacing all involve semantic interpretation. Be transparent about your reasoning. When you make a judgment call (e.g., merging two findings as duplicates, or classifying a finding's phase), state your reasoning. You do NOT add your own findings or pick winners in disagreements.
 
 **Your responsibilities:**
+0. **Filter by confidence (do this first)** — skip any finding with confidence < 80 before aggregating. For JSONL findings, check the `confidence` field. For markdown findings, check the `**Confidence:**` field. Low-confidence findings are excluded from the summary entirely. (A future review notes tier will surface them separately.)
 1. **Deduplicate** — group findings from different reviewers that address the same issue. Note which reviewers flagged each (consensus signal: more reviewers = higher confidence).
 2. **Classify by phase** — assign each finding a primary phase (where the fix should happen) and optionally a contributing phase (upstream cause). If >30% of findings share a contributing phase, flag as "systemic issue detected — consider escalating to [phase]."
 3. **Surface contradictions** — when reviewers disagree, present both positions with the tension noted. Do NOT resolve contradictions.
@@ -87,6 +88,7 @@ You are the Review Synthesizer — an editorial agent that consolidates findings
 - **Section:** [which part of the design]
 - **Issue:** [consolidated description]
 - **Why it matters:** [consolidated impact]
+- **Confidence:** [highest confidence among reviewers who flagged this finding]
 - **Suggestion:** [consolidated suggestion, noting different reviewer suggestions if they diverge]
 - **Fixability:** auto-fixable | human-decision
 - **Status:** pending
@@ -120,4 +122,4 @@ You are the Review Synthesizer — an editorial agent that consolidates findings
 - **human-decision:** Everything else. Requires human accept/reject.
 List auto-fixable findings in a separate section at the top of the summary.
 
-**Important:** Your job is to make the review usable, not to filter it. Include everything. The user decides what to act on.
+**Important:** Include all findings that passed the confidence ≥ 80 filter. Do not further filter by your own judgment — verdict logic and deduplication handle everything else. The user decides what to act on after seeing the consolidated summary.

--- a/agents/scope-guardian.md
+++ b/agents/scope-guardian.md
@@ -52,6 +52,7 @@ Produce JSONL findings using this structure:
   "id": "scope-guardian-NNN",
   "title": "Brief finding title",
   "severity": "Critical|Important|Minor",
+  "confidence": 85,
   "phase": {
     "primary": "calibrate",
     "contributing": null
@@ -68,6 +69,21 @@ Produce JSONL findings using this structure:
 - **Important:** Scope ambiguous, out-of-scope not stated, creep risks high (causes rework)
 - **Minor:** Clarity improvements, documentation gaps
 
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
+
 **Blind spot check:**
 
 After completing your review, add a meta-finding:
@@ -78,6 +94,7 @@ After completing your review, add a meta-finding:
   "id": "scope-guardian-999",
   "title": "Blind spot check: Scope Guardian perspective",
   "severity": "Minor",
+  "confidence": 50,
   "phase": {
     "primary": "calibrate",
     "contributing": null

--- a/agents/success-validator.md
+++ b/agents/success-validator.md
@@ -52,6 +52,7 @@ Produce JSONL findings using this structure:
   "id": "success-validator-NNN",
   "title": "Brief finding title",
   "severity": "Critical|Important|Minor",
+  "confidence": 85,
   "phase": {
     "primary": "calibrate",
     "contributing": null
@@ -68,6 +69,21 @@ Produce JSONL findings using this structure:
 - **Important:** Success criteria vague, not measurable (causes rework)
 - **Minor:** Clarity improvements, documentation gaps
 
+**Before scoring confidence, rule out false positives. Do NOT report findings that:**
+- Are implementation details rather than design or requirement gaps
+- Reference requirements or constraints not present in the document (hallucinated constraints)
+- Express style preferences with no structural impact
+- Speculate about hypothetical future concerns not relevant to the current document
+- Duplicate another finding from a different angle without adding new information
+- Require external knowledge (project history, prior sessions) to evaluate — must be assessable from the document alone
+
+**Confidence rubric (0-100 — assign to every finding):**
+- **0**: Not confident — does not stand up to light scrutiny
+- **25**: Somewhat confident — might be real, could not fully verify from document alone
+- **50**: Moderately confident — verified present, but minor or low-frequency in practice
+- **75**: Highly confident — double-checked, directly supported by document evidence, will impact design validity
+- **100**: Certain — confirmed, will definitely cause problems if not addressed
+
 **Blind spot check:**
 
 After completing your review, add a meta-finding:
@@ -78,6 +94,7 @@ After completing your review, add a meta-finding:
   "id": "success-validator-999",
   "title": "Blind spot check: Success Validator perspective",
   "severity": "Minor",
+  "confidence": 50,
   "phase": {
     "primary": "calibrate",
     "contributing": null

--- a/schemas/reviewer-findings-v1.0.0.schema.json
+++ b/schemas/reviewer-findings-v1.0.0.schema.json
@@ -12,7 +12,7 @@
   "$defs": {
     "finding": {
       "type": "object",
-      "required": ["type", "id", "title", "severity", "phase", "section", "issue", "why_it_matters", "suggestion"],
+      "required": ["type", "id", "title", "severity", "confidence", "phase", "section", "issue", "why_it_matters", "suggestion"],
       "properties": {
         "type": { "const": "finding" },
         "id": {
@@ -24,6 +24,12 @@
         "severity": {
           "type": "string",
           "enum": ["Critical", "Important", "Minor"]
+        },
+        "confidence": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 100,
+          "description": "Reviewer self-scored confidence (0-100). Synthesizer filters out findings below 80."
         },
         "phase": {
           "type": "object",

--- a/tests/fixtures/valid-finding.jsonl
+++ b/tests/fixtures/valid-finding.jsonl
@@ -1,2 +1,2 @@
-{"type": "finding", "id": "v3-assumption-hunter-001", "title": "Test Finding", "severity": "Critical", "phase": {"primary": "design", "contributing": null}, "section": "Test Section", "issue": "This is a test issue", "why_it_matters": "Testing", "suggestion": "Fix it"}
+{"type": "finding", "id": "v3-assumption-hunter-001", "title": "Test Finding", "severity": "Critical", "confidence": 85, "phase": {"primary": "design", "contributing": null}, "section": "Test Section", "issue": "This is a test issue", "why_it_matters": "Testing", "suggestion": "Fix it"}
 {"type": "blind_spot_check", "content": "I may have missed implementation details."}


### PR DESCRIPTION
## Summary

- **All 10 reviewer agents** updated with confidence self-scoring (0-100 rubric + explicit false-positive exclusion list matching ADR-007 judge criteria). JSONL agents add `"confidence": N` field; markdown agents add `**Confidence:** N/100` to finding template.
- **Schema** (`reviewer-findings-v1.0.0.schema.json`): `confidence` added as required integer (0-100) to the `finding` type.
- **Synthesizer** (`review-synthesizer.md`): filters out findings with confidence < 80 before aggregation. Low-confidence findings excluded from summary (Issue #83 will add a review notes tier).
- **Scorer** (`reverse_judge_scorer.py`): `reverse_judge_precision` now emits `confidence_stratified` metadata — per-band precision for high (≥80) vs low (<80) confidence findings. Calibration diagnostic: high-confidence findings should approach 100% judge precision; mismatches signal prompt quality issues.
- **Tests**: 89 passing, +6 new tests for confidence-stratified precision.

## Rubric (identical across all agents, mirrors code-review plugin)

- **0**: Not confident — does not stand up to light scrutiny
- **25**: Somewhat confident — might be real, could not fully verify from document alone
- **50**: Moderately confident — verified present, but minor or low-frequency in practice
- **75**: Highly confident — double-checked, directly supported by document evidence
- **100**: Certain — confirmed, will definitely cause problems if not addressed

## Test plan

- [x] `pytest tests/` — 89 passed, 0 failures
- [x] Schema change verified: `confidence` in `required` array + typed as `integer 0-100`
- [x] All 5 JSONL agents: `confidence` field in both main finding and blind spot check examples
- [x] All 5 markdown agents: `**Confidence:** 85/100` in finding template
- [x] Synthesizer: confidence < 80 filter in step 0 of responsibilities
- [x] Scorer: `confidence_stratified` metadata with `high_confidence` / `low_confidence` bands

Closes #72.

🤖 Generated with [Claude Code](https://claude.com/claude-code)