### PR TITLE
steer: use make install for worktree venv setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ The name comes from parallax — the apparent shift in an object's position when
 
 Always `cd` to the worktree first via a full absolute path (`cd /full/path && ...`) so all subsequent commands run in the correct context. Never use `make -C` or relative paths like `.worktrees/...` — they fail when shell CWD doesn't match.
 
+**Venv setup in worktrees:** When a worktree needs Python dependencies, run `make install` from the worktree directory — do not run separate `python3 -m venv` + pip commands. The `make install` target creates `.venv-evals/`, installs `.[dev]`, and sets up required directories in one step. (Doc-only or config-only worktrees that need no Python can skip this.)
+
 ## Subagent Tool Discipline
 
 Subagents inherit these rules. **Use dedicated tools, not bash equivalents:**

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VENV        := .venv-evals/bin/activate
 
 install:
 	@if [ ! -f $(VENV) ]; then python3 -m venv .venv-evals; fi
-	. $(VENV) && pip install -e ".[dev]" -q
+	.venv-evals/bin/pip install -e ".[dev]" -q
 	mkdir -p logs/ evals/baselines/
 	@which gitleaks > /dev/null 2>&1 && echo "gitleaks already installed" || brew install gitleaks
 


### PR DESCRIPTION
## Summary

- **Makefile**: `install` target now uses `.venv-evals/bin/pip` directly instead of `. $(VENV) && pip` — source activation violates the global venv rule and generates an extra permission prompt.
- **CLAUDE.md**: Rule added to Worktree Workflow section — when a worktree needs Python deps, run `make install` instead of separate `python3 -m venv` + pip commands.

## Why

Encoding a correction: worktree setup was done manually with multiple python/pip commands this session instead of using the existing `make install` target. The rule prevents recurrence. The Makefile fix ensures `make install` is safe to invoke without violating the global no-source-activation rule.

## Test plan

- [x] `make install` creates `.venv-evals/` and installs `.[dev]` without source activation
- [x] Pre-commit hook passes (no secrets, not on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)