### PR TITLE
docs: confidence eval analysis — #73/#79 plans, synthesis, adversarial review

### DIFF
--- a/docs/adversarial-73-79-review.md
+++ b/docs/adversarial-73-79-review.md
@@ -1,0 +1,228 @@
+# Adversarial review: issue #73 (judge calibration gate) and issue #79 (autoevals Factuality)
+
+**Date:** 2026-02-18
+**Reviewer:** Opus (adversarial)
+**Scope:** Stress-test reasoning, surface weak assumptions, identify omissions
+
+---
+
+## Issue #79 (autoevals Factuality) -- REJECT decision
+
+### 1. "No natural question exists" is wrong
+
+The plan claims there is no natural mapping for the `input` slot. This is dismissive. The frozen document is the context. The finding is the claim. The natural question is: "Based on this document, is this finding identifying a real problem?"
+
+This is exactly entailment-with-negation. Factuality's framing -- "is the output consistent with the expected given the input" -- maps to "is the finding consistent with what the document actually says." The plan waves this off as "no natural question" without trying the obvious mapping:
+
+- `input`: "Evaluate whether this finding identifies a real, document-visible design flaw."
+- `output`: The finding text (title + issue + severity).
+- `expected`: The frozen document content.
+
+This is not a clean fit -- `expected` is a reference corpus, not an expert answer -- but the plan never articulates why this specific mapping fails. It asserts difficulty and moves on.
+
+The honest argument is: Factuality is designed for factual claims against reference text, not for absence-detection claims ("the document fails to specify X"). RAGAS was rejected for this exact reason in ADR-008. The #79 plan should have made this argument explicitly instead of the weaker "no natural question" framing.
+
+**Verdict:** The rejection is probably correct, but for a reason the plan buries. The real killer is absence-detection, not input mapping.
+
+### 2. The binary gate argument is weak standing alone
+
+The plan says Factuality's partial credit (categories A-E) "directly violates" the binary gate. But thresholding is trivial: score >= 0.5 maps to GENUINE, score < 0.5 maps to NOT_GENUINE. Every classification system can be binarized.
+
+The plan's counterargument -- "at that point you've built a custom scorer anyway" -- is undersold. The real problem is that Factuality's categories encode the wrong semantics:
+
+- Category B (superset, consistent, 0.6): A finding that says more than the document states scores positively. But a finding that hallucinates extra constraints also says more than the document states. Category B cannot distinguish genuine inference from hallucination.
+- Category E (unrelated subjects, 1.0): An irrelevant finding scores maximum. This is absurd for genuineness checking.
+- Category A (subset, consistent, 0.4): A finding that is narrower than the expected answer scores below the binary threshold. A genuine finding that only partially captures a flaw would be classified NOT_GENUINE.
+
+The category semantics are designed for answer comparison, not claim verification. The plan touches this but does not hammer it home. The binary gate is not the problem -- the wrong ontology is the problem.
+
+**Verdict:** The binary gate argument is necessary context but insufficient as a standalone reason. Strengthen it or drop it.
+
+### 3. Desk rejection without experiment is defensible -- barely
+
+ADR-008 rejected G-Eval after an experiment. The #79 plan rejects Factuality at desk. The plan says the mismatch is "semantic, not calibration-related" to justify this.
+
+The difference between G-Eval and Factuality: G-Eval is a prompting technique applied to the same judge (Haiku). It tests whether the judge prompt can be improved. Factuality is a different scoring framework with different semantics. The question for G-Eval was "does reasoning-first help?" -- you have to run it to know. The question for Factuality is "does this framework measure what we need?" -- which is answerable by analysis.
+
+But there is one thing an experiment could reveal that desk analysis cannot: what does Factuality's agreement rate with the current Haiku judge look like? If Factuality (via gpt-4o) agrees with Haiku on 90% of verdicts, that is evidence the Haiku judge is well-calibrated. If it disagrees on 50%, that is evidence of systematic divergence worth investigating. The plan does not consider Factuality as a calibration cross-check even after rejecting it as a primary scorer.
+
+This is a missed opportunity. The experiment would be cheap (12 findings, one API call each to gpt-4o, total cost under $0.50). The plan should either run it or explicitly argue why cross-model agreement data is not useful.
+
+**Verdict:** Desk rejection is defensible for the primary scorer question but misses the cross-check opportunity.
+
+### 4. gpt-4o dependency is not a real blocker
+
+The plan lists "requires Braintrust proxy or LiteLLM translation" as infrastructure overhead. The project has Codex access, an explicit $50-100/month OpenAI budget, and gpt-4o is available via standard API. LiteLLM is `pip install litellm` and one environment variable.
+
+This is a convenience objection masquerading as an architectural objection. If gpt-4o Factuality produced better calibration data than Haiku, the integration cost is one afternoon. The plan should not list this as a supporting argument for rejection.
+
+**Verdict:** Drop this argument. It weakens the overall case by including a trivially solvable objection.
+
+---
+
+## Issue #73 (judge calibration gate) plan
+
+### 5. Circularity in the GENUINE partition
+
+The plan says: use the 6 `real_flaw` entries from `critical_findings.jsonl` as the GENUINE partition. These entries were manually validated -- but by whom, and against what standard?
+
+Looking at the actual data: the `critical_findings.jsonl` entries have `"validation_status": "real_flaw"` set by the project author. The Haiku judge was NOT used to validate them originally -- they were human-validated. So the specific circularity of "using judge output to calibrate the judge" does not apply.
+
+But there is a subtler problem. The entries were validated by the same person who wrote the requirements document, the reviewer agent prompts, and the judge prompt. If the author's understanding of "genuine" differs from the judge's understanding, the calibration set measures disagreement between author and judge -- not absolute accuracy.
+
+This is not inherently wrong (the author is the ground truth authority), but the plan should state this explicitly: the calibration set's GENUINE partition defines "genuine" as "the author says so." If the judge disagrees with the author on a finding the author considers genuine, the plan assumes the judge is wrong. That assumption should be explicit because it constrains what the calibration gate can detect.
+
+What it cannot detect: systematic bias the author shares with the judge. If both author and judge agree that a certain class of finding is genuine but an external expert would disagree, the calibration gate passes anyway.
+
+**Verdict:** Not circular, but the limitation should be stated. The plan treats GENUINE as objective when it is author-subjective.
+
+### 6. N=12 is not "acceptable for MVP" -- it is statistically uninformative for its stated purpose
+
+The plan acknowledges "one wrong judgment shifts specificity/sensitivity by 17pp." This is not a minor caveat -- it is the central limitation.
+
+Consider: the specificity threshold is 5/6 (83%). The judge must correctly reject 5 of 6 NOT_GENUINE examples. If the judge is actually 70% specific (genuinely miscalibrated), the probability of seeing 5/6 correct by chance is:
+
+P(5 or 6 correct | true specificity = 0.70) = C(6,5) * 0.70^5 * 0.30^1 + C(6,6) * 0.70^6 = 6 * 0.168 * 0.30 + 0.118 = 0.303 + 0.118 = 0.42
+
+A 42% chance of passing a genuinely miscalibrated judge. That is not a gate -- it is a coin flip.
+
+For the sensitivity side, same math applies. A judge with true sensitivity of 0.70 has a 42% chance of passing the 5/6 threshold.
+
+The plan says this is "acceptable for MVP." But the issue's stated purpose is "validate a metric before trusting it." An instrument with 42% probability of passing a broken metric does not validate anything. It generates false confidence.
+
+The minimum useful calibration set for detecting a judge at 70% vs 90% with 80% power requires roughly 25-30 examples per partition. At 6 per partition, the gate is cosmetic.
+
+**Verdict:** This is the plan's most serious problem. Either increase N substantially or reframe the gate's purpose from "validation" to "smoke test that catches only catastrophic failures (e.g., judge that accepts everything or rejects everything)." The current framing overpromises.
+
+### 7. The 83% threshold is unprincipled
+
+The plan says 83% because "one miss tolerable." This is convenience arithmetic, not a calibration decision.
+
+The right question: what judge error rate makes the precision metric unreliable? If the judge has 83% specificity, then 17% of NOT_GENUINE findings leak through as GENUINE. With 5 reviewers producing ~10 findings each and 80% being NOT_GENUINE (the observed rate), that is 40 NOT_GENUINE findings, of which ~7 leak through. The precision metric inflates by roughly 7/(7+10) = ~41% relative error. Is that acceptable?
+
+If the judge has 83% sensitivity, then 17% of GENUINE findings get rejected. With ~10 GENUINE findings across all reviewers, ~2 get dropped. Precision deflates slightly. This is less damaging.
+
+The asymmetry matters: specificity errors (leniency) inflate precision more than sensitivity errors (strictness) deflate it, because NOT_GENUINE findings vastly outnumber GENUINE ones. The threshold for specificity should be higher than for sensitivity, not equal.
+
+The plan sets them equal at 83%. This treats strictness errors and leniency errors as equally harmful when the observed data (72-93% NOT_GENUINE) makes leniency errors far more impactful.
+
+**Verdict:** The threshold should be asymmetric. Specificity needs to be higher (5/6 minimum, ideally 6/6) while sensitivity can be lower. At minimum, the plan should justify symmetric thresholds against the observed base rate.
+
+### 8. Standalone script vs Inspect AI task has a real cost
+
+The plan argues that calibration has no generation step, so Inspect AI's generate-then-score pattern does not apply. This is technically correct.
+
+But the cost is not architectural -- it is operational. Inspect AI logs produce structured JSON with timestamps, model names, scores, and metadata. The calibration script will produce... what? A print statement? A JSON file with ad hoc schema?
+
+If calibration results are not in Inspect AI log format, they cannot be compared across runs using the same tooling. When the judge model changes (Haiku version bump, swap to Sonnet), re-running calibration and comparing to the previous run requires either writing comparison code or eyeballing output.
+
+The plan should specify: what is the output format? Where do results go? How do you detect calibration regression when the judge model updates?
+
+Also: the "no generation step" argument is weaker than presented. You could wrap the calibration check as an Inspect AI task where the "solver" is a no-op (returns the finding as-is) and the scorer runs the judge. This is inelegant but keeps everything in one log format. The plan dismisses this option without considering the operational cost of the alternative.
+
+**Verdict:** Not blocking, but the plan has an operational gap. Specify the output format and regression detection workflow, or accept the Inspect AI wrapper's inelegance.
+
+---
+
+## Interaction between #73 and #79
+
+### 9. #73 still has a purpose, but a narrower one
+
+With #79 rejected, there is no second scorer to compare against. The calibration gate's purpose shrinks from "validate judge before comparing to alternatives" to "validate judge, period."
+
+This is still useful, but the value proposition weakens. The original sequence (#73 calibrates judge, then #79 compares Factuality) had a clear payoff: calibration data fed into a comparison. Now calibration stands alone. The question becomes: what decision does calibration enable?
+
+If the calibration gate passes: "the judge is not catastrophically broken, proceed." This is useful but low-information.
+
+If the calibration gate fails: "the judge is miscalibrated, fix it before trusting precision." This is useful and high-information.
+
+The asymmetry means the gate is only valuable if there is a plausible path to failing. Given that the direct judge already achieves 84.6% accuracy on clean ground truth (G-Eval experiment), the calibration gate probably passes. The plan should consider: is there enough prior evidence of miscalibration to justify building the gate? Or is the first precision baseline (7-28%) sufficient evidence that the problem is reviewer quality, not judge quality?
+
+**Verdict:** #73 is still worth doing as a smoke test, but the plan should acknowledge the narrower scope and reduced expected value.
+
+### 10. Factuality's semantic analysis is uninformative about the Haiku judge
+
+The #79 plan says the mismatch is "semantic, not calibration-related." This is correct but the implication is underexplored.
+
+The Haiku judge IS making semantic judgments. It is deciding whether a finding "identifies a real problem visible in the document" and whether the finding "references requirements not present in the document." These are entailment-adjacent decisions.
+
+The fact that Factuality's entailment framing does not cleanly map to genuineness checking tells us that genuineness checking is more nuanced than entailment. It does not tell us whether the Haiku judge handles that nuance correctly. Specifically:
+
+- Factuality would fail on absence-detection findings (as noted in ADR-008 for RAGAS).
+- The Haiku judge also needs to handle absence-detection findings -- is "the document does not specify X" a genuine finding or a hallucinated constraint?
+
+The #79 analysis identifies that Factuality cannot distinguish these cases. But neither plan asks: can Haiku? The G-Eval experiment showed Haiku has a 28.6% false negative rate, and the cases it misses are context-dependent findings that look genuine from the document alone. This is the same entailment ambiguity that makes Factuality unsuitable -- but it is also present in the current judge.
+
+**Verdict:** The semantic analysis of Factuality's limitations should feed back into the judge prompt design. Both plans miss this connection.
+
+---
+
+## Broader situation
+
+### 11. The calibration inversion has an unexplored alternative explanation
+
+The plans frame the calibration inversion (high-confidence findings have lower precision for assumption-hunter and constraint-finder) as either a judge error or a reviewer error. There is a third option neither plan addresses: the confidence rubric interacts differently with different reviewer types.
+
+Look at the agent prompts. All five reviewers use identical confidence rubric text:
+
+> - 0: Not confident -- does not stand up to light scrutiny
+> - 25: Somewhat confident -- might be real, could not fully verify from document alone
+> - 50: Moderately confident -- verified present, but minor or low-frequency in practice
+> - 75: Highly confident -- double-checked, directly supported by document evidence, will impact design validity
+> - 100: Certain -- confirmed, will definitely cause problems if not addressed
+
+The 75 anchor says "directly supported by document evidence." For problem-framer, scope-guardian, and success-validator, this maps naturally to their task: they look for missing sections, unclear criteria, and unresolved questions. The document either has the section or it does not. High confidence means "I checked and the section is missing."
+
+For assumption-hunter and constraint-finder, "directly supported by document evidence" maps poorly. An unstated assumption is by definition NOT directly evidenced in the document. The assumption-hunter's job is to identify what is NOT there. When the assumption-hunter assigns 85 confidence, it means "I am very confident this assumption exists" -- but the supporting evidence is inferential, not direct. The judge then looks for direct document evidence, finds none (because the assumption is unstated), and calls it NOT_GENUINE.
+
+The rubric creates a systematic mismatch for absence-detection reviewers. High confidence for these reviewers correlates with deeper inference, which correlates with less direct document evidence, which correlates with NOT_GENUINE verdicts. The inversion is a rubric-task interaction, not a judge error or a reviewer error.
+
+Additionally, the quantity effect matters. Assumption-hunter and constraint-finder produce 13 findings each vs 7-10 for others. More findings means more marginal findings, which dilutes precision mechanically. The plans do not separate "per-finding quality is lower" from "more findings means more chances for NOT_GENUINE" -- these are different failure modes with different fixes.
+
+**Verdict:** The confidence rubric needs reviewer-type-specific anchoring. Absence-detection reviewers need an anchor like "75: the absence is clearly relevant to the document's stated scope and purpose" instead of "directly supported by document evidence." Neither plan identifies this.
+
+### 12. What if the judge is right?
+
+Neither plan seriously considers the possibility that 7-28% precision is accurate. The framing throughout is "precision is low, find out why" with an implied "and fix it." But what if reviewers genuinely hallucinate 72-93% of their findings?
+
+The evidence supports this more than either plan admits:
+
+- The quality_failures directory documents real cases of reviewers producing implementation details as Critical findings, duplicating resolved issues, and confusing requirements with design.
+- The G-Eval experiment found the direct judge achieves 84.6% accuracy on clean ground truth -- it is mostly right.
+- The judge reasoning in NOT_GENUINE calls is described as "largely correct" in the #73 plan itself: "reviewers ARE producing hallucinated constraints, hypothetical concerns, and meta-reflections."
+
+If the judge is right, then:
+
+1. **The calibration gate (#73) will pass**, confirming the judge is working correctly. Then what? The plan has no "judge is correct, precision really is 7-28%" branch.
+
+2. **The project's reviewer agents need fundamental redesign**, not better eval infrastructure. Five reviewers producing 7-13 findings each with 72-93% hallucination rate means the review panel generates ~50 findings of which ~5-10 are genuine. The signal-to-noise ratio is approximately 1:9.
+
+3. **The confidence scoring feature (#72) is addressing the wrong problem.** If reviewers cannot distinguish genuine from hallucinated findings (the calibration inversion shows they cannot, at least for assumption-hunter and constraint-finder), then confidence is not a useful filter -- it is a hallucinated metacognitive signal applied to hallucinated findings.
+
+4. **The synthesizer (review-synthesizer agent) becomes the critical component.** If individual reviewers have 7-28% precision, the synthesizer must achieve far higher precision by cross-referencing and filtering. This is a harder problem than either plan scopes.
+
+The plans should include a "judge is correct" contingency. At minimum: if the calibration gate passes and precision remains 7-28%, what is the next action? Prompt engineering on reviewer agents? Reducing reviewer count? Raising the severity threshold? The current plan sequence (#73 then nothing) leaves a dead end if the judge validates.
+
+**Verdict:** This is the most significant gap across both documents. The plans assume low precision is a measurement problem. If it is a production problem, the entire #73/#79 workstream is solving the wrong issue.
+
+---
+
+## Summary of findings by severity
+
+**Critical (blocks the plan's purpose):**
+- Point 6: N=12 calibration set has 42% probability of passing a genuinely miscalibrated judge. The gate does not validate what it claims to validate.
+- Point 12: No contingency for "judge is correct and precision really is 7-28%." Plans address measurement validity without addressing production validity.
+
+**Important (weakens the plan, should fix before implementation):**
+- Point 7: Symmetric thresholds ignore the base rate asymmetry. Specificity matters more than sensitivity when 72-93% of findings are NOT_GENUINE.
+- Point 11: Calibration inversion is likely a rubric-task interaction, not a judge error. Neither plan identifies this, and #73 cannot detect it.
+- Point 5: GENUINE partition relies on author-subjective validation. Limitation should be stated.
+- Point 3: Missed opportunity to use Factuality as a cross-model calibration check even after rejecting it as primary scorer.
+
+**Minor (correct but undersold or oversold):**
+- Point 1: "No natural question" is the wrong argument; absence-detection is the right argument.
+- Point 2: Binary gate argument is necessary context but wrong as standalone rejection reason.
+- Point 4: gpt-4o dependency is not a real blocker. Drop this argument.
+- Point 8: Standalone script needs an output format specification and regression detection plan.
+- Point 9: #73 still useful but with narrower scope; plan should acknowledge.
+- Point 10: Factuality's semantic analysis should feed back into judge prompt design.

--- a/docs/findings-73-79-synthesis-2026-02-18.md
+++ b/docs/findings-73-79-synthesis-2026-02-18.md
@@ -1,0 +1,261 @@
+# Issues #73 / #79 — Synthesis & Findings
+
+**Date:** 2026-02-18
+**Session:** feat/confidence-eval worktree, first precision/recall baseline run
+**Sources:** docs/issue-73-plan.md, docs/issue-79-plan.md, docs/adversarial-73-79-review.md
+
+---
+
+## Issue #79 — autoevals Factuality
+
+### Decision: REJECT (confirmed)
+
+The desk rejection in the plan is correct, but the arguments used were weak. The ADR-quality
+argument is:
+
+**Absence-detection is the fundamental mismatch.** Reviewer findings identify what is *not* in
+the document ("the document fails to specify X"). Factuality measures whether a claim is
+*consistent with* a reference text. It cannot evaluate an absence claim — the same reason RAGAS
+was rejected in ADR-008. This is the correct rejection argument.
+
+### Arguments to drop
+
+- **"No natural question exists"** — wrong. The frozen document can be `expected`, the finding
+  can be `output`. The mapping is awkward but not nonexistent. The real problem is absence-detection,
+  not input mapping.
+
+- **"Requires Braintrust proxy or LiteLLM"** — trivially solvable. Project has Codex access and
+  $50-100/month OpenAI budget. This is a convenience objection masquerading as an architectural
+  one.
+
+- **"Binary gate violation"** — necessary context but insufficient as a standalone argument.
+  Any scoring system can be thresholded. The real problem is that Factuality's category semantics
+  (category B: superset scores 0.6; category E: unrelated topics scores 1.0) are designed for
+  answer comparison, not claim verification. The wrong ontology is the problem, not the partial
+  credit per se.
+
+### Missed opportunity
+
+Even after rejecting Factuality as a primary scorer, running it as a **cross-model calibration
+check** was not considered. 12 findings × ~$0.04/call = ~$0.50 to see if gpt-4o and Haiku agree
+on verdicts. If agreement is 90%, that's evidence Haiku is well-calibrated. If agreement is 50%,
+that's a red flag worth investigating. This experiment is cheap enough to run before or alongside
+#73. Not blocking, but worth noting.
+
+### ADR-008 status
+
+The "maybe — evaluate Factuality" open item from ADR-008 is now resolved. Prior art sweep is
+complete:
+- RAGAS: skip (entailment mismatch)
+- G-Eval: reject (same FN rate, 10x latency, session 32)
+- Braintrust platform: skip (keep Inspect AI)
+- autoevals Factuality: reject (absence-detection mismatch, binary gate ontology)
+
+---
+
+## Issue #73 — Judge Calibration Gate
+
+### The gate as designed is statistically uninformative
+
+N=12 (6 per partition) gives a **42% probability of passing a genuinely miscalibrated judge**
+at 70% true specificity.
+
+```
+P(5 or 6 correct | true_specificity=0.70)
+  = C(6,5) × 0.70^5 × 0.30^1 + C(6,6) × 0.70^6
+  = 0.303 + 0.118
+  = 0.42
+```
+
+A gate with 42% false-pass probability does not validate anything — it generates false confidence.
+The plan's claim of "acceptable for MVP" is inconsistent with "validate the metric before trusting
+it." Those goals require different N.
+
+**Resolution options:**
+1. Increase to ~25-30 examples per partition for meaningful statistical power (detects 70% vs 90%
+   true accuracy at ~80% power)
+2. Reframe explicitly as a **smoke test for catastrophic failures only** (catches judge that accepts
+   everything or rejects everything) — N=12 is fine for this narrower purpose
+
+The current plan should not ship without choosing one of these options and stating it clearly.
+
+### Thresholds should be asymmetric
+
+The plan sets both specificity and sensitivity thresholds at 83% (5/6). This treats leniency
+errors and strictness errors as equally harmful. They are not.
+
+With 72–93% of findings being NOT_GENUINE:
+- A specificity error (judge accepts a false positive) inflates precision significantly.
+  With ~40 NOT_GENUINE findings across all reviewers, 17% leniency = ~7 leaked FPs.
+  Precision inflates by ~7/(7+10) ≈ 41% relative error.
+- A sensitivity error (judge rejects a true positive) deflates precision modestly.
+  With ~10 GENUINE findings total, 17% strictness = ~2 dropped TPs.
+
+**Specificity threshold should be higher than sensitivity threshold.** At minimum, the plan
+must justify symmetric thresholds against the observed base rate.
+
+Recommendation: specificity ≥ 6/6 (100%) or 5/6 with explicit acknowledgment of leniency risk;
+sensitivity ≥ 4/6 (67%) — one miss is low-cost given the base rate.
+
+### The GENUINE partition relies on author-subjective validation
+
+The plan uses the 6 `real_flaw` entries from `critical_findings.jsonl` as the known-GENUINE
+partition. These were human-validated — the Haiku judge was NOT used to validate them. No
+circularity.
+
+But: they were validated by the same person who wrote the requirements document, reviewer agent
+prompts, and judge prompt. The calibration set defines "genuine" as "the author says so." If
+the judge disagrees with the author, the plan assumes the judge is wrong. This assumption should
+be stated explicitly.
+
+What the gate cannot detect: systematic bias shared between author and judge. An external expert
+might disagree with both. Not a reason to abandon the approach — the author is the ground truth
+authority — but the limitation should be documented.
+
+### Standalone script output format is unspecified
+
+The plan recommends a standalone Python script over an Inspect AI task. Technically correct —
+calibration has no generation step. But the operational cost is real: Inspect AI produces
+structured JSON logs that are comparable across runs. A standalone script produces... what?
+
+The plan must specify: output format, output location, and how calibration regression is detected
+when the judge model updates (Haiku version bump, swap to Sonnet). If the output is not
+comparable across runs, the gate is a one-shot check, not a regression test.
+
+Alternative: wrap calibration as an Inspect AI task where the solver is a no-op (passes the
+finding as-is) and the scorer runs the judge. Inelegant but keeps everything in one log format.
+
+### Narrower scope with #79 closed
+
+The original plan sequence was: #73 calibrates judge → #79 compares Factuality against calibrated
+judge. With #79 rejected, calibration stands alone. The value proposition weakens:
+
+- **Gate passes:** "judge is not catastrophically broken, proceed." Low-information.
+- **Gate fails:** "judge is miscalibrated, fix before trusting precision." High-information.
+
+The gate is only high-value if there is a plausible path to failing. Given the G-Eval experiment
+showed the direct judge at 84.6% accuracy on clean ground truth, the gate will likely pass. The
+plan should acknowledge this and state what a pass means operationally.
+
+---
+
+## The Calibration Inversion — Root Cause
+
+### Rubric-task mismatch, not judge error
+
+The confidence rubric anchor at 75 reads: *"directly supported by document evidence."*
+
+**Requirements-focused reviewers** (problem-framer, scope-guardian, success-validator): their
+job is to find missing sections, undefined criteria, unresolved questions. The document either
+has the section or it doesn't. High confidence = "I checked, the section is absent." The rubric
+fits. Calibration direction is correct (high-conf precision > low-conf precision).
+
+**Absence-detection reviewers** (assumption-hunter, constraint-finder): their job is to find
+what is NOT stated. An unstated assumption is by definition not evidenced in the document. When
+these reviewers assign confidence 85, they mean "I am very confident this assumption exists" —
+but the evidence is inferential, not direct. The judge looks for document support, finds none,
+calls it NOT_GENUINE. The calibration inversion is **mechanical and expected** given the rubric.
+
+Additionally, quantity effects matter. Assumption-hunter and constraint-finder produce 13 findings
+each vs 7-10 for other reviewers. More findings = more marginal findings = mechanically lower
+per-finding precision. "Per-finding quality is lower" and "more findings means more chances for
+NOT_GENUINE" are different failure modes with different fixes. The plans do not separate them.
+
+### Fix
+
+Update the 75-confidence anchor for absence-detection reviewers. Instead of:
+
+> 75: Highly confident — double-checked, directly supported by document evidence, will impact
+> design validity
+
+Use something like:
+
+> 75: Highly confident — the absence is clearly relevant to the document's stated scope and
+> purpose; the document creates a context in which this gap would be expected to be addressed
+
+This preserves the intent (high confidence = well-grounded) while fitting the inference-based
+nature of absence detection.
+
+---
+
+## The Critical Missing Question: What If the Judge Is Right?
+
+Neither the #73 plan nor the #79 plan addresses the most important scenario: **precision is
+genuinely 7–28%, and the judge is correct.**
+
+The evidence supports this more than either plan acknowledges:
+- The judge reasoning on NOT_GENUINE calls is described in the #73 plan as "largely correct"
+- G-Eval experiment showed the direct judge at 84.6% accuracy on clean ground truth
+- The `quality_failures/` directory documents real hallucination patterns: implementation details
+  as Critical findings, duplications of resolved issues, requirements/design confusion
+
+**If the judge is right, the implications are:**
+
+1. **The calibration gate will pass.** The plan has no "judge is correct, now what" branch.
+
+2. **Reviewer agents need fundamental redesign.** Five reviewers producing 7-13 findings each
+   at 72-93% hallucination rate means ~50 total findings of which ~5-10 are genuine. Signal-to-noise
+   ≈ 1:9.
+
+3. **The confidence feature (#72) is addressing the wrong layer.** If reviewers cannot
+   distinguish genuine from hallucinated (the calibration inversion shows assumption-hunter and
+   constraint-finder cannot, under the current rubric), then confidence is a metacognitive signal
+   applied to hallucinated findings. The rubric fix (see above) is necessary before confidence
+   filtering is meaningful.
+
+4. **The synthesizer becomes the critical component.** If individual reviewers have 7-28%
+   precision, the synthesizer must achieve far higher precision through cross-referencing and
+   filtering. That is a harder problem than the current plan scopes.
+
+**This should be explicit in the #73 plan:** if the calibration gate passes and precision remains
+low, the next action is reviewer prompt redesign — not more eval infrastructure.
+
+---
+
+## Impact on the feat/confidence-eval Branch
+
+### What's working
+
+- `confidence` field emitted consistently on all 5 reviewers ✓
+- Schema validation passes (required field, 0-100 integer) ✓
+- `confidence_stratified` metadata in scorer output ✓
+- Synthesizer filter at threshold 80 ✓ (but see below)
+
+### Why the branch should not land yet
+
+1. **Synthesizer filter is backwards for absence-detection reviewers.** The filter removes
+   findings with `confidence < 80`. For assumption-hunter and constraint-finder, the
+   low-confidence findings have *higher* genuine precision (0.125/0.143 vs 0.000 for
+   high-confidence). The filter is removing the relatively more-genuine findings for those two
+   reviewers.
+
+2. **Calibration inversion documented in eval results.** Merging with inverted calibration
+   makes the confidence feature actively misleading in production — users would see high-confidence
+   findings from assumption-hunter that are systematically worse than low-confidence ones.
+
+### Path to landing
+
+1. **Fix the confidence rubric** for assumption-hunter and constraint-finder (absence-detection
+   anchor language). Single-file edits to `agents/assumption-hunter.md` and
+   `agents/constraint-finder.md`.
+
+2. **Re-run `make reviewer-eval`** to verify calibration inversion disappears for those two
+   reviewers. If high-conf precision > low-conf precision for all five reviewers, the branch
+   is ready.
+
+3. **Update eval results doc** with the re-run data.
+
+4. **Proceed with #73** as a smoke test (reframe scope, adjust N or explicitly label as
+   catastrophic-failure detector, add "judge is correct" contingency, fix threshold asymmetry).
+
+5. **Close #79** with corrected reasoning in the issue comment.
+
+---
+
+## Next Session Start Point
+
+- Worktree: `feat/confidence-eval`
+- First action: fix absence-detection anchor in assumption-hunter.md and constraint-finder.md
+- Second action: `make reviewer-eval`, check calibration direction
+- If calibration fixes: update eval results doc, update MEMORY.md, proceed toward merge
+- If calibration persists: deeper investigation of reviewer prompts before landing

--- a/docs/issue-72-completion-notes.md
+++ b/docs/issue-72-completion-notes.md
@@ -1,0 +1,102 @@
+# Issue #72 — Completion Notes
+
+## State right now (worktree `feat/confidence-eval`)
+
+- 10 old `findings-v1-*.jsonl` files staged for `git rm` — not yet committed
+- Schema has `confidence` **wrongly changed to optional** — needs reverting
+- Nothing else in the worktree
+
+---
+
+## Step 1 — Revert the schema change
+
+In the worktree, `schemas/reviewer-findings-v1.0.0.schema.json` has `confidence` missing from the `required` array. Put it back:
+
+```json
+"required": ["type", "id", "title", "severity", "confidence", "phase", "section", "issue", "why_it_matters", "suggestion"]
+```
+
+Main already has this correct. The worktree diverged. Revert `schemas/reviewer-findings-v1.0.0.schema.json` to match main, then `git add` it.
+
+---
+
+## Step 2 — Commit what's staged
+
+```bash
+cd /Users/nic/src/design-parallax/parallax/.worktrees/feat/confidence-eval
+git add schemas/reviewer-findings-v1.0.0.schema.json
+git commit -m "remove pre-confidence historic findings, keep confidence required"
+```
+
+---
+
+## Step 3 — Run the eval
+
+```bash
+cd /Users/nic/src/design-parallax/parallax/.worktrees/feat/confidence-eval
+make reviewer-eval
+```
+
+Runs all 5 reviewer tasks (assumption-hunter, constraint-finder, problem-framer, scope-guardian,
+success-validator) against both datasets. Produces fresh `findings-v1-*.jsonl` files with
+`confidence` on every finding.
+
+---
+
+## Step 4 — Read the results
+
+Look for two things:
+
+**a) Did recall hold?**
+The `must_find_recall` score should be at or near 1.0 for each reviewer. If any must_find entry
+dropped out, the synthesizer's `confidence < 80` filter may have suppressed it. That's the thing
+to investigate — not a ground truth problem, a threshold problem.
+
+**b) Did schema pass?**
+If any finding is missing `confidence`, the schema validator will reject it. That means a reviewer
+prompt isn't emitting the field consistently. Fix the prompt, re-run.
+
+---
+
+## Step 5 — Update ground truth (only if needed)
+
+The `must_find` entries do **not** need a `confidence` field added to them. They test topic
+coverage, not calibration. Leave them as-is unless:
+
+- Recall regressed: a previously-found entry is now missed → investigate the synthesizer threshold,
+  don't remove the must_find entry
+- A fresh finding is obviously critical and missing from must_find → add it
+
+---
+
+## Step 6 — Commit results + open PR
+
+```bash
+git add docs/reviews/
+git commit -m "feat: fresh confidence eval findings, validate confidence field required"
+```
+
+Push and open PR. Close #72 when merged.
+
+---
+
+## Follow-on: Issue #79 (Factuality scorer)
+
+\#79 was blocked on #72 because it needs real `confidence` data to calibrate against. After #72
+closes:
+
+1. Look at the distribution of `confidence` values on must_find findings — are reviewers scoring
+   obvious critical flaws at 85+, or hedging at 60?
+2. That distribution is the calibration baseline for the Factuality scorer.
+3. The scorer tests whether confidence correlates with genuineness — high-confidence NOT_GENUINE
+   findings indicate a miscalibrated reviewer.
+4. Don't design the scorer until you have the distribution data from step 1.
+
+---
+
+## What you don't need to do
+
+- Don't add `confidence` to `must_find.jsonl` entries (wrong layer)
+- Don't add `min_confidence` expectations anywhere (that's #79's job, and only after data)
+- Don't remove must_find entries because confidence scores look low — that's a calibration signal,
+  not a ground truth error

--- a/docs/issue-73-plan.md
+++ b/docs/issue-73-plan.md
@@ -1,0 +1,106 @@
+# Issue #73 — Judge Calibration Gate: Implementation Plan
+
+Generated: 2026-02-18, based on first precision/recall baseline from feat/confidence-eval.
+
+## Revised Scope: Judge May Be Too Strict, Not Too Lenient
+
+Original issue assumed the risk was leniency (judge says GENUINE to everything). First baseline
+shows the opposite: precision is 7–28%, meaning the judge calls 72–93% of findings NOT_GENUINE.
+
+Reading the judge reasoning shows the NOT_GENUINE calls are largely correct — reviewers ARE
+producing hallucinated constraints, hypothetical concerns, and meta-reflections that deserve
+NOT_GENUINE. But some verdicts are arguable, and calibration inversion for assumption-hunter and
+constraint-finder raises the question of systematic over-strictness.
+
+**The calibration gate must test both directions:**
+1. Known NOT_GENUINE (judge should reject) — catches leniency
+2. Known GENUINE (judge should accept) — catches over-strictness
+
+## Calibration Set Design
+
+### Partition A: 6 known NOT_GENUINE (hand-crafted, one per FP category)
+
+Each crafted against the v2 frozen document, unambiguously in one FP category.
+
+| Category | Description |
+|---|---|
+| implementation_detail | No CI/CD pipeline specification for running eval suite |
+| hallucinated_constraint | References Docker containerization requirement in "Section 4.2" (no such section) |
+| style_preference | Phase names should use lowercase-hyphenated format instead of "Phase 1", "Phase 1.5" |
+| hypothetical_future | If reviewer count grows beyond 20, eval cost scaling will exceed budget |
+| duplicate | Rephrase an existing real_flaw from a different angle without new information |
+| context_dependent | Phase 1 exit criteria conflict with "the original v1 thresholds from January session" (requires MEMORY.md knowledge) |
+
+### Partition B: 6 known GENUINE (from v2 critical_findings.jsonl real_flaws)
+
+Copy the 6 `real_flaw` entries from `datasets/inspect-ai-integration-requirements-v2/critical_findings.jsonl`,
+add `"expected_verdict": "GENUINE"`. Self-contained — no cross-file references. These are manually
+validated real flaws; the judge should accept them.
+
+**Total: 12 calibration examples against v2 frozen document.**
+
+## Acceptance Thresholds
+
+- **Specificity** (true negative rate, Partition A): ≥ 5/6 (83%). One miss tolerable — "duplicate"
+  and "context_dependent" categories have inherent ambiguity. Below 5/6 = judge too lenient,
+  precision metric is inflated.
+
+- **Sensitivity** (true positive rate, Partition B): ≥ 5/6 (83%). One miss tolerable. Below 5/6 =
+  judge too strict, precision metric is deflated. This is the new concern.
+
+**Both thresholds must pass.** MVP: informational, not blocking `make reviewer-eval`. Phase 2: hard gate.
+
+## Files
+
+### New
+
+| File | Purpose |
+|---|---|
+| `datasets/calibration/false_positive_examples.jsonl` | 6 hand-crafted NOT_GENUINE findings, one per FP category |
+| `datasets/calibration/genuine_examples.jsonl` | 6 real_flaw entries from v2 dataset with `expected_verdict: GENUINE` |
+| `datasets/calibration/metadata.json` | design_doc_path → v2 frozen doc, thresholds, version |
+| `evals/judge_calibration_eval.py` | Standalone Python script (not Inspect AI task — see below) |
+| `tests/evals/test_judge_calibration.py` | Unit tests with mocked judge |
+
+### Modified
+
+| File | Change |
+|---|---|
+| `Makefile` | Add `calibrate-judge` target: `.venv-evals/bin/python evals/judge_calibration_eval.py` |
+
+### Not modified
+
+`evals/reviewer_eval.py` — calibration is informational at MVP, not blocking reviewer eval.
+
+## Implementation: Standalone Script, Not Inspect AI Task
+
+Inspect AI tasks assume `generate()` produces model output, then scorers evaluate it. Calibration
+has no generation step — we're testing the scorer's internal judge, not a reviewer agent.
+A standalone script calls `_reverse_judge_one` directly and prints category-level pass/fail.
+
+This is simpler, faster to build, and easier to run. If Inspect AI integration is later wanted,
+wrap the script results.
+
+## Ordering: #73 Before #79
+
+#79 (autoevals Factuality) compares a second scorer against `reverse_judge_precision` to measure
+agreement/disagreement. If the judge itself isn't calibrated, ensembling two uncalibrated signals
+is meaningless.
+
+**#73 unblocks:**
+- **#79 directly** — trust the judge before comparing it to alternatives
+- **Judge prompt iteration** — calibration set becomes the regression test if sensitivity fails
+- **Confidence stratification interpretation** — "high-conf precision = 0.000" for assumption-hunter
+  may be a judge error, not genuine calibration inversion. Can't tell until judge is calibrated.
+- **Ground truth expansion** — if judge passes calibration, 7–28% precision is real (reviewers
+  hallucinate that much), and effort shifts to reviewer prompt improvement
+
+## Risks
+
+**Small calibration set (N=12):** One wrong judgment shifts specificity/sensitivity by 17pp. Low
+statistical power for subtle drift. Acceptable for MVP — the machinery is what matters; set grows
+over time.
+
+**FP examples too easy:** If hand-crafted examples are obviously absurd, gate passes but doesn't
+prove borderline handling. Mitigation: model on the `datasets/quality_failures/` examples — those
+are real-world FP patterns.

--- a/docs/issue-79-plan.md
+++ b/docs/issue-79-plan.md
@@ -1,0 +1,131 @@
+# Issue #79: autoevals Factuality Scorer — Research & Decision
+
+**Date:** 2026-02-18
+**Issue:** #79 (Evaluate autoevals Factuality scorer as supplementary precision signal)
+**Outcome:** REJECT
+**Related:** ADR-008, docs/research/prior-art-braintrust-vercel-2026-02-17.md
+
+---
+
+## 1. Scope
+
+Issue #79 asked: can Braintrust's `autoevals` Factuality scorer serve as a supplementary precision signal or cross-check against `reverse_judge_precision`?
+
+The prior art research (ADR-008) flagged `autoevals` as a "maybe — evaluate Factuality scorer as supplementary signal." That open question is resolved here.
+
+**Conclusion:** REJECT. The mismatch is semantic, not calibration-related. No experiment needed.
+
+---
+
+## 2. What Factuality Does
+
+`autoevals.Factuality` compares a submitted answer (`output`) against an expert answer (`expected`) given a question (`input`). It uses a 5-category rating with partial credit:
+
+| Category | Meaning | Score |
+|----------|---------|-------|
+| A | Output is a subset of expected, fully consistent | 0.4 |
+| B | Output is a superset of expected, fully consistent | 0.6 |
+| C | Output and expected are equivalent | 1.0 |
+| D | Output and expected disagree | 0.0 |
+| E | Output and expected differ but are on unrelated subjects | 1.0 |
+
+Under the hood, `Factuality` is built on `LLMClassifier`: a Mustache prompt template that asks the model to pick a category, with tool-call extraction mapping the choice to a 0-1 score. Default model is gpt-4o; Claude requires Braintrust proxy or LiteLLM tool-call translation.
+
+---
+
+## 3. Input Mapping Analysis
+
+Factuality assumes: `input` = question, `output` = submitted answer, `expected` = expert answer.
+
+Design review findings don't map to this frame:
+
+| Factuality slot | Natural meaning | Parallax forced mapping | Problem |
+|-----------------|-----------------|------------------------|---------|
+| `input` | A question | The frozen document? The review prompt? | No natural question exists |
+| `output` | The answer being graded | A reviewer finding | Findings are claims, not answers |
+| `expected` | The expert answer | ??? | There is no "expert answer" for genuineness |
+
+The question for genuineness is: *"Is this finding supported by the document?"* There is no expert answer — that's exactly what we're trying to determine. `expected` would have to be the document itself, which Factuality would then treat as the gold-standard answer to an implied question. This is a forced mapping with no semantic grounding.
+
+Any attempt to fit findings into the Factuality frame requires writing logic to construct artificial `input`/`expected` values — at which point you have built a custom scorer anyway, and the Factuality abstraction adds nothing.
+
+---
+
+## 4. Category Mismatch with the Genuineness Gate
+
+CLAUDE.md states: **the genuineness gate is binary.** A finding is GENUINE or NOT_GENUINE. Partial credit is explicitly prohibited:
+
+> "Once you allow NOT_GENUINE findings to score positively because they seem humanly useful, every false positive gets a defense and the precision metric becomes meaningless."
+
+Factuality's partial credit structure directly violates this guardrail:
+
+- A hallucinated finding that's a "superset" of something in the document (category B) scores 0.6 — a false positive rewarded.
+- A finding that's "on a different topic" from the expert answer (category E) scores 1.0 — semantically irrelevant to genuineness.
+- The only "this is wrong" category (D, score 0.0) conflates a different kind of disagreement than "this finding is fabricated."
+
+Mapping 5-category partial-credit scores to a binary gate would require thresholding (score > X → GENUINE). This reintroduces calibration complexity while inheriting the conceptual mismatch. It doesn't simplify; it complicates.
+
+---
+
+## 5. Model and Infrastructure Notes
+
+The default model for `autoevals` Factuality is gpt-4o. Running it with Claude requires either:
+- **Braintrust proxy:** routes OpenAI-format calls to Claude. Adds SaaS dependency.
+- **LiteLLM:** translates tool-call schemas between providers. Adds local infrastructure.
+
+Neither is a blocker, but the overhead is real for a scorer that doesn't fit the domain. Inspect AI already has native Anthropic provider support with no translation layer.
+
+---
+
+## 6. Ordering Answer (Moot)
+
+Issue #73 (judge calibration gate) listed as a prerequisite: "*#73 before #79.*" The intent was: don't evaluate a supplementary scorer before establishing whether the primary judge is miscalibrated.
+
+This dependency is now moot. The reject decision is based on semantic mismatch, not calibration concerns. Even if #73 found the Haiku judge to be severely miscalibrated, Factuality would still be the wrong remedy — it operates on a different task definition and violates the binary gate requirement.
+
+---
+
+## 7. Decision
+
+**REJECT autoevals Factuality as a supplementary scorer.**
+
+| Criterion | Assessment |
+|-----------|------------|
+| Input mapping fit | Poor — no natural question/answer frame for design findings |
+| Binary gate compatibility | Incompatible — partial credit violates CLAUDE.md guardrail |
+| Model support | Requires translation layer for Claude |
+| Added value over `reverse_judge_precision` | None — would need custom scaffolding to approximate what the existing scorer already does cleanly |
+
+**This is the same class of rejection as RAGAS in ADR-008:** an entailment/factuality framework applied to a binary-gate classification problem. The prior art sweep pattern holds.
+
+---
+
+## 8. What to Adopt from autoevals
+
+One engineering pattern is worth noting for future reference:
+
+**`LLMClassifier` base class** — Mustache prompt template + `choice_scores` dict + tool-call extraction. Clean separation of prompt template, choice mapping, and score extraction. If we ever need an alternative to Inspect AI's `@scorer` decorator API (e.g., for a TypeScript-adjacent context or cross-platform scorer portability), `LLMClassifier` is the reference implementation to study.
+
+No code to adopt now. Note is for future reference only.
+
+---
+
+## 9. Relationship to ADR-008
+
+ADR-008 covers the prior art sweep: RAGAS (skip), Braintrust (keep Inspect AI, consider autoevals), Vercel (skip), G-Eval (reject for Haiku). The "consider autoevals" note in ADR-008 is now resolved:
+
+- Issue #76 (Braintrust platform): SKIP — keep Inspect AI. Documented in prior art research.
+- Issue #79 (autoevals Factuality): REJECT — category mismatch with binary gate. Documented here.
+- Issue #75 (G-Eval): REJECTED — same FN rate, worse FP rate, 10x latency. Documented.
+
+**ADR-008 prior art sweep is now complete.** All "maybe" items have been investigated and resolved.
+
+---
+
+## Sources
+
+- [autoevals Factuality source (GitHub)](https://github.com/braintrustdata/autoevals)
+- [LLMClassifier implementation](https://github.com/braintrustdata/autoevals/blob/main/py/autoevals/llm.py)
+- `docs/research/prior-art-braintrust-vercel-2026-02-17.md` — Issues #76 and #78 analysis
+- ADR-008 (G-Eval experiment, session 32) — recorded in MEMORY.md
+- CLAUDE.md §"Eval Design Guardrails" — the genuineness gate is binary

--- a/docs/plans/2026-02-18-confidence-eval-completion.md
+++ b/docs/plans/2026-02-18-confidence-eval-completion.md
@@ -1,0 +1,172 @@
+# Plan: Complete #72 Confidence Eval — Full Next Steps
+
+**Date:** 2026-02-18
+**Branch:** feat/confidence-eval (PR #89)
+**Worktree:** `/Users/nic/src/design-parallax/parallax/.worktrees/feat/confidence-eval`
+
+## Context
+
+PR #89 (feat/confidence-eval) has confidence scoring working mechanically but has two problems
+blocking merge:
+
+1. **Calibration inversion** for assumption-hunter and constraint-finder: high-confidence findings
+   have 0% precision, low-confidence have 12-14%. Root cause: the 75-confidence anchor says
+   "directly supported by document evidence" which doesn't fit absence-detection reviewers.
+
+2. **Unknown judge accuracy**: precision of 7-28% could be real (reviewers hallucinate) or
+   inflated strictness (judge miscalibrated). Manual spot-check of real findings is the fastest
+   way to determine judge accuracy.
+
+Additionally: #79 needs closing with corrected reasoning, #73 needs redesign.
+
+## Sequence (sequential, not parallel)
+
+Rubric fix first, then spot-check the post-fix findings. Reasoning:
+- Rubric fix is justified regardless of judge accuracy (mechanical mismatch)
+- Spot-checking post-fix findings evaluates the system we'd actually ship
+- G-Eval experiment (84.6% judge accuracy) gives reasonable prior that judge is mostly right
+
+---
+
+### Step 1 — Fix absence-detection rubric
+
+**Session:** Claude Code in feat/confidence-eval worktree
+
+Files:
+- `agents/assumption-hunter.md`
+- `agents/constraint-finder.md`
+
+Change the 75-confidence anchor from:
+> 75: Highly confident — double-checked, directly supported by document evidence, will impact
+> design validity
+
+To something like:
+> 75: Highly confident — the gap or unstated assumption is clearly relevant to the document's
+> stated scope and purpose; the document creates a context in which this issue would be expected
+> to be addressed
+
+Leave the other anchors (0, 25, 50, 100) unchanged.
+Leave the 3 requirements-focused reviewers unchanged (calibration direction already correct).
+
+---
+
+### Step 2 — Re-run eval
+
+```bash
+cd /Users/nic/src/design-parallax/parallax/.worktrees/feat/confidence-eval
+make reviewer-eval
+```
+
+Check calibration direction for all 5 reviewers. Success = high-conf precision > low-conf
+precision for assumption-hunter and constraint-finder. If inversion persists: deeper prompt issue.
+
+Write results to `docs/evals/reviewer-eval-2026-02-18-post-rubric-fix.md`.
+Commit rubric fix + new eval results.
+
+---
+
+### Step 3 — Extract post-fix findings for spot-check
+
+Write an extraction script that reads the 5 .eval log files and outputs a markdown review doc.
+
+Per finding:
+- Finding ID, title, severity, confidence score
+- Issue text (the finding's claim)
+- Judge verdict (GENUINE / NOT_GENUINE)
+- Judge reasoning (full text)
+- Checkbox: `[ ] AGREE  [ ] DISAGREE  [ ] UNSURE`
+
+Extraction data lives in `sample.scores['reverse_judge_precision'].metadata['judge_results']`:
+```python
+{"finding_id": "...", "finding_title": "...", "confidence": 90, "is_genuine": bool, "reasoning": "..."}
+```
+
+Use `inspect_ai.log.read_eval_log()` to read .eval files.
+
+Output: `docs/evals/spot-check-post-rubric-fix.md`
+
+**Sampling:** Review all findings (~52). At ~1 min each, ~1 hour human time.
+Alternative: sample 25 (all GENUINE + stratified NOT_GENUINE). Label explicitly if sampled.
+
+---
+
+### Step 4 — Human spot-check
+
+For each finding: read the claim, read the judge reasoning, check the frozen document if needed.
+Mark AGREE / DISAGREE / UNSURE.
+
+Frozen documents:
+- v2: `datasets/inspect-ai-integration-requirements-v2/inspect-ai-integration-requirements-v2.md`
+- light: `datasets/inspect-ai-integration-requirements-light/inspect-ai-integration-requirements-v1.md`
+
+---
+
+### Step 5 — Calculate judge accuracy
+
+Count: AGREE / (AGREE + DISAGREE). Break down by:
+- Overall accuracy
+- Accuracy on GENUINE vs NOT_GENUINE verdicts (sensitivity vs specificity)
+- Accuracy by reviewer type (absence-detection vs requirements-focused)
+- Accuracy by confidence band (high ≥80 vs low <80)
+
+Write results to `docs/evals/judge-accuracy-post-rubric-fix.md`.
+
+**Decision point:**
+- Judge accuracy ≥ 80%: judge is trustworthy → precision numbers are real → proceed to merge
+- Judge accuracy < 80%: fix judge prompt → re-run eval → re-spot-check
+- Accuracy diverges by reviewer type: tells us exactly where judge struggles
+
+---
+
+### Step 6 — Issue cleanup (can run anytime, independent)
+
+**Close #79:**
+- REJECT confirmed by adversarial review
+- Correct argument: absence-detection mismatch (same root cause as RAGAS in ADR-008)
+- Drop the "gpt-4o dependency" and "no natural question" arguments
+- Note missed $0.50 cross-check opportunity
+- ADR-008 prior art sweep now complete
+
+**Update #73:**
+- Original approach (synthetic calibration set N=12) replaced by manual spot-check
+- N=12 has 42% false-pass probability — not a real validation gate
+- Manual spot-check of real findings is strictly better (real data, larger N)
+- Spot-check results from Step 5 ARE the calibration data
+- Synthetic calibration eval may become a regression test later
+
+---
+
+### Step 7 — Merge gate
+
+PR #89 can merge when ALL of:
+1. Calibration inversion gone for assumption-hunter and constraint-finder (Step 2)
+2. Judge accuracy ≥ 80% on spot-check (Step 5)
+3. #79 closed, #73 updated (Step 6)
+
+If all pass: merge PR #89, close #72.
+If judge accuracy is low: fix judge prompt, re-run, re-spot-check. Branch stays open.
+
+---
+
+## Files Modified
+
+| File | Step | Change |
+|---|---|---|
+| `agents/assumption-hunter.md` | 1 | 75-anchor rewording |
+| `agents/constraint-finder.md` | 1 | 75-anchor rewording |
+| `docs/evals/reviewer-eval-2026-02-18-post-rubric-fix.md` | 2 | Post-fix eval results (new) |
+| `docs/evals/spot-check-post-rubric-fix.md` | 3 | Extraction for human review (new) |
+| `docs/evals/judge-accuracy-post-rubric-fix.md` | 5 | Spot-check results (new) |
+
+## Verification
+
+1. After Step 2: `make reviewer-eval` completes clean, all 5 reviewers produce findings with confidence
+2. After Step 2: high-conf precision > low-conf precision for ALL 5 reviewers
+3. After Step 5: judge accuracy number calculated and documented
+4. After merge: `git log --oneline main..feat/confidence-eval` shows clean commit history
+
+## Parallel Session Allocation
+
+- **Session 1:** Steps 1-2 (rubric fix + eval run)
+- **Session 2:** Step 6 (issue cleanup — gh commands only, independent)
+- **Session 3:** Steps 3-5 (extraction + human review + accuracy calc — after Session 1 completes)


### PR DESCRIPTION
## Summary

Session 34 research artifacts for the confidence eval workstream. No code changes.

- **issue-72-completion-notes.md**: step-by-step guide written at session start (superseded by execution)
- **issue-73-plan.md**: judge calibration gate plan, revised scope (both-direction testing, not just leniency)
- **issue-79-plan.md**: autoevals Factuality — REJECT with reasoning
- **adversarial-73-79-review.md**: Opus adversarial review of both plans (12 findings across 4 severity levels)
- **findings-73-79-synthesis-2026-02-18.md**: full synthesis — corrected arguments, root cause analysis, path to landing #89

## Key findings documented

- **Calibration inversion root cause**: rubric anchor "directly supported by document evidence" is a poor fit for absence-detection reviewers (assumption-hunter, constraint-finder). Their findings are inferential by definition. Fix: scope-relevance anchor for the 75 band.
- **#79 REJECT correct reasoning**: absence-detection mismatch (not "no natural question"). Same root cause as RAGAS (ADR-008). ADR-008 prior art sweep now complete.
- **#73 N=12 is cosmetic**: 42% false-pass probability at 70% true specificity. Reframe as smoke test or increase to 25-30 per partition.
- **"What if the judge is right?" gap**: neither plan addressed the contingency where 7-28% precision is accurate. Added to synthesis.

## Related
- PR #89 (feat/confidence-eval) — blocked on rubric fix, not merging until calibration inversion resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)